### PR TITLE
Handle missing OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ uv run recipe-extractor.py "https://youtube.com/watch?v=abc123" \
 1. **Missing OpenAI API Key**
 
    ```
-   Error: OpenAI API key not found
+   Error: OPENAI_API_KEY not set
    ```
 
    Solution: Set up your `.env` file or environment variable

--- a/recipe-extractor.py
+++ b/recipe-extractor.py
@@ -7,8 +7,10 @@ import json
 from dotenv import load_dotenv
 load_dotenv()
 
-## TODO: manage the case where the key is not present
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY") 
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    print("Error: OPENAI_API_KEY not set")
+    sys.exit(1)
 AUDIO_FILE = "audio.mp3"
 
 def download_audio_with_ytdlp(url, out_file=AUDIO_FILE):


### PR DESCRIPTION
## Summary
- check `OPENAI_API_KEY` when recipe-extractor starts
- document the new error message

## Testing
- `python -m py_compile recipe-extractor.py`

------
https://chatgpt.com/codex/tasks/task_e_6842936e4ec8833196cad0a56bcdd531