### PR TITLE
Add pytest for markdown converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ uv run recipe-extractor.py "video-url" --save-transcript debug.txt
 
 Then review `debug.txt` to see the raw transcription.
 
+## Running Tests 🧪
+
+After installing the optional development dependencies, run the test suite with:
+
+```bash
+pytest
+```
+
 ## Contributing 🤝
 
 1. Fork the repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,8 @@ dependencies = [
     "openai>=1.84.0",
     "yt-dlp>=2025.5.22",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.1.1",
+]

--- a/tests/test_convert_to_markdown.py
+++ b/tests/test_convert_to_markdown.py
@@ -1,0 +1,41 @@
+import json
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+# Provide stub modules so the script can be imported without optional deps
+sys.modules.setdefault("yt_dlp", types.ModuleType("yt_dlp"))
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+# Dynamically load the convert_to_markdown function from recipe-extractor.py
+spec = importlib.util.spec_from_file_location(
+    "recipe_extractor", Path(__file__).resolve().parents[1] / "recipe-extractor.py"
+)
+recipe_extractor = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(recipe_extractor)
+convert_to_markdown = recipe_extractor.convert_to_markdown
+
+def test_convert_to_markdown_basic():
+    sample = {
+        "title": "Sample Recipe",
+        "ingredients": ["1 cup flour", "2 eggs"],
+        "steps": ["Mix ingredients", "Bake"],
+        "tips": ["Let it cool"],
+        "servings": "2",
+        "healthiness": {"indicator": "🟢 Green", "rationale": "Very healthy"},
+    }
+    md = convert_to_markdown(json.dumps(sample))
+
+    assert "# Sample Recipe" in md
+    assert "**Servings:** 2" in md
+    assert "## Ingredients" in md
+    assert "- 1 cup flour" in md
+    assert "## Instructions" in md
+    assert "1. Mix ingredients" in md
+    assert "## Tips & Tricks" in md
+    assert "## Health Assessment" in md
+    assert "🟢 Green Very healthy" in md


### PR DESCRIPTION
## Summary
- add optional dev dependency on pytest
- document how to run tests
- add simple unit test for `convert_to_markdown`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684294c7a75483319976bbd543bbda66