### PR TITLE
Fix French markdown section headings

### DIFF
--- a/recipe-extractor.py
+++ b/recipe-extractor.py
@@ -117,33 +117,52 @@ Transcription:
     )
     return response.choices[0].message.content
 
-def convert_to_markdown(recipe_json):
-    """Convert recipe JSON to markdown format"""
+def convert_to_markdown(recipe_json, language="english"):
+    """Convert recipe JSON to markdown format with localized section headings."""
     recipe = json.loads(recipe_json)
-    
+
+    headings = {
+        "english": {
+            "servings": "Servings",
+            "ingredients": "Ingredients",
+            "instructions": "Instructions",
+            "tips": "Tips & Tricks",
+            "health": "Health Assessment",
+        },
+        "french": {
+            "servings": "Portions",
+            "ingredients": "Ingr\u00e9dients",
+            "instructions": "Instructions",
+            "tips": "Astuces",
+            "health": "\u00c9valuation de la sant\u00e9",
+        },
+    }
+
+    labels = headings.get(language.lower(), headings["english"])
+
     markdown = f"# {recipe['title']}\n\n"
-    
-    markdown += f"**Servings:** {recipe['servings']}\n\n"
-    
-    markdown += "## Ingredients\n"
+
+    markdown += f"**{labels['servings']}:** {recipe['servings']}\n\n"
+
+    markdown += f"## {labels['ingredients']}\n"
     for ingredient in recipe['ingredients']:
         markdown += f"- {ingredient}\n"
     markdown += "\n"
-    
-    markdown += "## Instructions\n"
+
+    markdown += f"## {labels['instructions']}\n"
     for i, step in enumerate(recipe['steps'], 1):
         markdown += f"{i}. {step}\n"
     markdown += "\n"
-    
+
     if recipe['tips']:
-        markdown += "## Tips & Tricks\n"
+        markdown += f"## {labels['tips']}\n"
         for tip in recipe['tips']:
             markdown += f"- {tip}\n"
         markdown += "\n"
-    
-    markdown += "## Health Assessment\n"
+
+    markdown += f"## {labels['health']}\n"
     markdown += f"{recipe['healthiness']['indicator']} {recipe['healthiness']['rationale']}\n"
-    
+
     return markdown
 
 def main():
@@ -218,7 +237,7 @@ Examples:
         print(f"✅ Structured recipe saved as {filename}")
     else:  # markdown
         filename = f"{base_filename}.md"
-        markdown_content = convert_to_markdown(structured_recipe)
+        markdown_content = convert_to_markdown(structured_recipe, args.language)
         with open(filename, "w", encoding="utf-8") as f:
             f.write(markdown_content)
         print(f"✅ Structured recipe saved as {filename}")

--- a/tests/test_convert_to_markdown.py
+++ b/tests/test_convert_to_markdown.py
@@ -43,3 +43,18 @@ def test_convert_to_markdown_basic():
     assert "## Tips & Tricks" in md
     assert "## Health Assessment" in md
     assert "🟢 Green Very healthy" in md
+
+
+def test_convert_to_markdown_french_headings():
+    sample = {
+        "title": "Recette Exemple",
+        "ingredients": ["1 tasse de farine"],
+        "steps": ["M\u00e9langer"],
+        "tips": [],
+        "servings": "2",
+        "healthiness": {"indicator": "🟢 Green", "rationale": "Tr\u00e8s sain"},
+    }
+    md = convert_to_markdown(json.dumps(sample), language="french")
+
+    assert "**Portions:** 2" in md
+    assert "## Ingr\u00e9dients" in md


### PR DESCRIPTION
## Summary
- localize markdown headings based on language
- update CLI to pass language when generating markdown
- test French heading translations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ee642f2c833190aac88e747d7587