### PR TITLE
Add MCP server with official SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Extract structured recipes from YouTube cooking videos using AI transcription an
 - 🟢 Health assessment with visual indicators
 - 🛡️ Anti-hallucination guardrails to prevent false ingredients
 - 📝 Optional transcription saving for debugging
+- 🌐 Can run as a REST API server or MCP server using the official SDK
 
 ## Prerequisites 📋
 
@@ -91,6 +92,27 @@ uv run recipe-extractor.py "https://youtube.com/watch?v=abc123" --language frenc
 uv run recipe-extractor.py "https://youtube.com/watch?v=abc123" --format markdown
 ```
 
+### Server Mode
+
+Run the tool as a small REST API server:
+
+```bash
+uv run recipe-extractor.py --server
+```
+
+The server exposes `/extract` with `url`, `language`, and `format` query parameters.
+
+### MCP Mode
+
+Start an MCP server using the official Python SDK. It communicates over stdio
+using the MCP handshake:
+
+```bash
+uv run recipe-extractor.py --mcp
+```
+
+Use an MCP-compatible client to invoke the `extract_recipe` tool.
+
 ### Advanced Usage
 
 ```bash
@@ -119,6 +141,8 @@ uv run recipe-extractor.py "https://youtube.com/watch?v=abc123" \
 | `--language`        | `-l`  | Output language (`english`/`french`) | `english`           |
 | `--format`          | `-f`  | Output format (`json`/`markdown`)    | `json`              |
 | `--save-transcript` |       | Save transcription to file           | Not saved           |
+| `--server`          | `-s`  | Run REST API server                  | off                 |
+| `--mcp`             | `-m`  | Run MCP server                       | off                 |
 | `--help`            | `-h`  | Show help message                    |                     |
 
 ## Output Format 📋

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "dotenv>=0.9.9",
     "openai>=1.84.0",
     "yt-dlp>=2025.5.22",
+    "mcp>=1.9",
 ]
 
 [dependency-groups]

--- a/recipe-extractor.py
+++ b/recipe-extractor.py
@@ -4,6 +4,8 @@ import os
 import sys
 import argparse
 import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -165,6 +167,112 @@ def convert_to_markdown(recipe_json, language="english"):
 
     return markdown
 
+
+def extract_recipe(url, language="english", output_format="json", save_transcript=None):
+    """High-level helper to extract a recipe from a URL and return it as a string."""
+    print(f"🎯 Extracting from URL: {url}")
+
+    print("⬇️  Downloading audio...")
+    download_audio_with_ytdlp(url)
+
+    print("🎙️  Transcribing audio...")
+    transcript = transcribe_whisper(AUDIO_FILE)
+
+    if save_transcript:
+        with open(save_transcript, "w", encoding="utf-8") as f:
+            f.write(transcript)
+
+    try:
+        os.remove(AUDIO_FILE)
+    except OSError:
+        pass
+
+    print(f"🤖 Extracting recipe using AI (language: {language})...")
+    structured_recipe = extract_recipe_with_gpt(transcript, language)
+
+    if output_format == "markdown":
+        return convert_to_markdown(structured_recipe, language)
+    else:
+        # ensure valid JSON formatting
+        return json.dumps(json.loads(structured_recipe), ensure_ascii=False)
+
+
+def run_rest_server(host="0.0.0.0", port=8000, *, serve_forever=True):
+    """Run a very small REST API server.
+
+    Parameters
+    ----------
+    host : str
+        Host interface to bind.
+    port : int
+        Port to listen on.
+    serve_forever : bool, optional
+        If ``True`` (default) block and serve forever. When ``False`` the
+        configured ``HTTPServer`` instance is returned without entering the
+        serving loop. This is useful for unit tests.
+    """
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path != "/extract":
+                self.send_error(404, "Not Found")
+                return
+
+            qs = parse_qs(parsed.query)
+            url = qs.get("url", [None])[0]
+            if not url:
+                self.send_error(400, "Missing url parameter")
+                return
+
+            language = qs.get("language", ["english"])[0]
+            fmt = qs.get("format", ["json"])[0]
+
+            try:
+                result = extract_recipe(url, language, fmt)
+            except Exception as e:
+                self.send_error(500, str(e))
+                return
+
+            if fmt == "markdown":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/markdown; charset=utf-8")
+            else:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(result.encode("utf-8"))
+
+    server = HTTPServer((host, port), Handler)
+    print(f"🚀 REST API running on http://{host}:{port}")
+    if serve_forever:
+        server.serve_forever()
+    return server
+
+
+def run_mcp_server(*, serve_forever: bool = True):
+    """Run an MCP server using the official Python SDK.
+
+    Parameters
+    ----------
+    serve_forever : bool, optional
+        When ``True`` (default) the server runs and blocks on stdio. When
+        ``False`` the :class:`FastMCP` instance is returned for manual control
+        and testing.
+    """
+
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("Recipe Extractor")
+
+    @mcp.tool(name="extract_recipe")
+    def extract(url: str, language: str = "english", format: str = "json") -> str:
+        return extract_recipe(url, language, format)
+
+    if serve_forever:
+        mcp.run()
+    return mcp
+
 def main():
     parser = argparse.ArgumentParser(
         description='Extract recipes from YouTube cooking videos',
@@ -178,7 +286,7 @@ Examples:
         ''',
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument('url', help='YouTube URL of the cooking video')
+    parser.add_argument('url', nargs='?', help='YouTube URL of the cooking video')
     parser.add_argument('--output', '-o', help='Output file name (without extension, will be added based on format)')
     parser.add_argument('--language', '-l', choices=['english', 'french'], default='english',
                        help='Language for recipe extraction (default: english)')
@@ -186,9 +294,21 @@ Examples:
                        help='Output format (default: json)')
     parser.add_argument('--save-transcript', nargs='?', const='transcription.txt', metavar='FILE',
                        help='Save transcription to file (default: transcription.txt if no filename provided)')
+    parser.add_argument('--server', '-s', action='store_true', help='Run REST API server')
+    parser.add_argument('--mcp', '-m', action='store_true', help='Run MCP server')
     
     args = parser.parse_args()
-    
+
+    if args.server:
+        run_rest_server()
+        return
+    if args.mcp:
+        run_mcp_server()
+        return
+
+    if not args.url:
+        parser.error("the following arguments are required: url")
+
     print(f"🎯 Starting recipe extraction from: {args.url}")
     print(f"🌍 Language: {args.language}")
     print(f"📄 Format: {args.format}")

--- a/tests/test_convert_to_markdown.py
+++ b/tests/test_convert_to_markdown.py
@@ -5,12 +5,11 @@ import os
 import sys
 import types
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python-sdk" / "src"))
+
 # Provide stub modules so the script can be imported without optional deps
 sys.modules.setdefault("yt_dlp", types.ModuleType("yt_dlp"))
 sys.modules.setdefault("openai", types.ModuleType("openai"))
-dotenv_stub = types.ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *args, **kwargs: None
-sys.modules.setdefault("dotenv", dotenv_stub)
 
 # Set dummy API key so recipe-extractor doesn't exit on import
 os.environ.setdefault("OPENAI_API_KEY", "test-key")

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -1,0 +1,75 @@
+import importlib.util
+import os
+import sys
+import types
+import anyio
+import json
+import threading
+import http.client
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python-sdk" / "src"))
+
+# Stubs for optional deps so recipe-extractor can be imported
+sys.modules.setdefault("yt_dlp", types.ModuleType("yt_dlp"))
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+spec = importlib.util.spec_from_file_location(
+    "recipe_extractor", Path(__file__).resolve().parents[1] / "recipe-extractor.py"
+)
+recipe_extractor = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(recipe_extractor)
+
+
+def test_rest_server_basic():
+    results = []
+
+    def fake_extract(url, language, fmt):
+        results.append((url, language, fmt))
+        return "{}" if fmt == "json" else "# ok"
+
+    recipe_extractor.extract_recipe = fake_extract
+
+    server = recipe_extractor.run_rest_server("127.0.0.1", 0, serve_forever=False)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port)
+        conn.request("GET", "/extract?url=http://v")
+        resp = conn.getresponse()
+        body = resp.read().decode()
+        assert resp.status == 200
+        assert body == "{}"
+        assert results == [("http://v", "english", "json")]
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_mcp_server_basic():
+    results = []
+
+    def fake_extract(url, language, fmt):
+        results.append((url, language, fmt))
+        return "done"
+
+    recipe_extractor.extract_recipe = fake_extract
+
+    mcp = recipe_extractor.run_mcp_server(serve_forever=False)
+
+    async def run():
+        from mcp.shared.memory import (
+            create_connected_server_and_client_session as client_session,
+        )
+
+        async with client_session(mcp._mcp_server) as client:
+            result = await client.call_tool("extract_recipe", {"url": "http://v"})
+            assert len(result.content) == 1
+            assert result.content[0].text == "done"
+
+    anyio.run(run)
+    assert results == [("http://v", "english", "json")]
+


### PR DESCRIPTION
## Summary
- implement MCP server using the official `mcp` SDK
- document new MCP mode in README
- depend on `mcp` package
- adjust unit tests for SDK based server

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684699e937248331961924b220201601