### PR TITLE
Fix transcript retrieval logic

### DIFF
--- a/recipe-extractor.py
+++ b/recipe-extractor.py
@@ -20,6 +20,12 @@ if not OPENAI_API_KEY:
     sys.exit(1)
 AUDIO_FILE = "audio.mp3"
 
+
+def is_youtube_url(url: str) -> bool:
+    """Return True if the URL points to YouTube."""
+    host = urlparse(url).netloc.lower()
+    return "youtube.com" in host or "youtu.be" in host
+
 def download_audio_with_ytdlp(url, out_file=AUDIO_FILE):
     # Remove extension from out_file since FFmpegExtractAudio will add it
     base_name = out_file.rsplit('.', 1)[0] if '.' in out_file else out_file
@@ -407,11 +413,14 @@ Examples:
     info = fetch_video_info(args.url)
     post_text = get_post_text(info)
 
-    caption_langs = get_caption_languages(info)
-    transcript = get_youtube_transcript(info.get('id'), caption_langs)
-    if transcript:
-        print("📝 Using existing YouTube transcript")
-    else:
+    transcript = None
+    if is_youtube_url(args.url):
+        caption_langs = get_caption_languages(info)
+        transcript = get_youtube_transcript(info.get('id'), caption_langs)
+        if transcript:
+            print("📝 Using existing YouTube transcript")
+
+    if not transcript:
         print("⬇️  Downloading audio...")
         download_audio_with_ytdlp(args.url)
 

--- a/tests/test_transcript_logic.py
+++ b/tests/test_transcript_logic.py
@@ -1,0 +1,64 @@
+import importlib.util
+import sys
+import types
+import os
+from pathlib import Path
+
+# Stub optional dependencies so the module can be imported
+sys.modules.setdefault("yt_dlp", types.ModuleType("yt_dlp"))
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+spec = importlib.util.spec_from_file_location(
+    "recipe_extractor", Path(__file__).resolve().parents[1] / "recipe-extractor.py"
+)
+recipe_extractor = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(recipe_extractor)
+
+def test_is_youtube_url_detection():
+    assert recipe_extractor.is_youtube_url("https://www.youtube.com/watch?v=abc")
+    assert recipe_extractor.is_youtube_url("https://youtu.be/abc")
+    assert not recipe_extractor.is_youtube_url("https://instagram.com/reel/abc")
+
+def test_main_only_uses_youtube_transcripts(tmp_path, monkeypatch):
+    calls = {"yt": 0}
+
+    def fake_fetch_info(url):
+        return {"id": "abc"}
+
+    monkeypatch.setattr(recipe_extractor, "fetch_video_info", fake_fetch_info)
+    monkeypatch.setattr(recipe_extractor, "get_post_text", lambda info: "")
+    monkeypatch.setattr(recipe_extractor, "get_caption_languages", lambda info: [])
+
+    def fake_get_transcript(video_id, langs=None):
+        calls["yt"] += 1
+        return "transcript"
+
+    monkeypatch.setattr(recipe_extractor, "get_youtube_transcript", fake_get_transcript)
+    monkeypatch.setattr(recipe_extractor, "download_audio_with_ytdlp", lambda url: None)
+    monkeypatch.setattr(recipe_extractor, "transcribe_whisper", lambda path: "audio")
+    monkeypatch.setattr(recipe_extractor, "extract_recipe_with_gpt", lambda t, l: "{}")
+    monkeypatch.setattr(recipe_extractor.os, "remove", lambda path: None)
+
+    # YouTube URL should trigger transcript fetch
+    monkeypatch.setattr(sys, "argv", [
+        "prog",
+        "https://youtube.com/watch?v=abc",
+        "--output",
+        str(tmp_path / "out")
+    ])
+    recipe_extractor.main()
+    assert calls["yt"] == 1
+
+    calls["yt"] = 0
+    # Instagram URL should not attempt YouTube transcript
+    monkeypatch.setattr(sys, "argv", [
+        "prog",
+        "https://instagram.com/reel/xyz",
+        "--output",
+        str(tmp_path / "out2")
+    ])
+    recipe_extractor.main()
+    assert calls["yt"] == 0


### PR DESCRIPTION
## Summary
- only attempt to fetch transcripts when URL is from YouTube
- expose `is_youtube_url` helper
- add tests covering transcript selection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a73ba5c608331b5332a669b24e487